### PR TITLE
check return value of gzclose to detect unfinished gzip stream

### DIFF
--- a/bin/geoipupdate.c
+++ b/bin/geoipupdate.c
@@ -529,7 +529,8 @@ static int gunzip_and_replace(geoipupdate_s * gu, const char *gzipfile,
                     "Gzip write error\n");
     }
     fclose(fhw);
-    gzclose(gz_fh);
+    int rc = gzclose(gz_fh);
+    exit_if(rc != 0, "Gzip read error while closing from %s\n", gzipfile);
     free(buffer);
     say_if(gu->verbose, "Rename %s to %s\n", file_path_test, geoip_filename);
     int err = rename(file_path_test, geoip_filename);


### PR DESCRIPTION
geoipupdate does not report error even though GeoIP.dat on updates.maxmind.com is unfinished gzip.
Return value of gzclose() should be checked because only gzclose() can detect incomplete gzip stream.

http://www.zlib.net/manual.html#Gzip

> Note that gzread does not return -1 in the event of an incomplete gzip stream. 
> This error is deferred until gzclose(), which will return Z_BUF_ERROR if the last gzread ended 
> in the middle of a gzip stream. Alternatively, gzerror can be used before gzclose to detect this case. 

---

I tested my commit on the fake update site.
##### fake update site

$ ll
-rw-r--r-- 1 root root 1061834 Oct  6 14:20 GeoIP.dat.gz.orig
$ head -c 1000000 GeoIP.dat.gz.orig  > GeoIP.dat.gz.unfinished
$ ll
-rw-r--r-- 1 root root 1000000 Oct 21 10:46 GeoIP.dat.gz.unfinished
-rw-r--r-- 1 root root 1061834 Oct  6 14:20 GeoIP.dat.gz.orig

/etc/nginx/conf.d/default.conf

```
server {
    listen       80;
    server_name  geoip.localdomain;
    root /usr/share/nginx/html_geoip/;
    location / {
        try_files $uri /GeoIP.dat.gz.unfinished;
    }
}
```
##### geoipupdate client

/usr/local/etc/GeoIP.conf

```
UserId YOUR_USER_ID_HERE
LicenseKey YOUR_LICENSE_KEY_HERE
ProductIds GeoIP2-Country 106
Host geoip.localdomain
Protocol http
```

$ ll
$  geoipupdate
Gzip read error while closing from /usr/local/share/GeoIP/GeoIP.dat.gz
$ ll
-rw-r--r-- 1 root root 1000000 Oct 21 10:57 GeoIP.dat.gz
