### PR TITLE
geoipupdate checks if database directory is writeable before continuing

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,11 @@
 GeoIP Update Change Log
 =======================
 
+Unreleased
+
+* `geoipupdate` now checks that the database directory is writable. If it
+  is not, it reports the problem and aborts.
+
 2.3.1 (2017-01-05)
 ------------------
 

--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ Then install `geoipupdate` by running:
 ## Installing From Source File
 
 To install this from the source package, you will need a C compiler, Make,
-and the curl library and headers. On Debian or Ubuntu, you can install these
-dependencies by running:
+the zlib library and headers, and the curl library and headers. On Debian
+or Ubuntu, you can install these dependencies by running:
 
-    $ sudo apt-get install build-essential libcurl4-openssl-dev
+    $ sudo apt-get install build-essential libcurl4-openssl-dev zlib1g-dev
 
 Once you have the necessary dependencies, run the following commands:
 


### PR DESCRIPTION
This is to avoid confusion arising from the previously opaque error message.

We now show something like:

```
will@9979ded0c36e:~$ geoipupdate 
/usr/local/share/GeoIP is not writable
```

I also opted to show the error if `fopen(3)` fails for another reason.

Note as you can see, I commented that `access(2)` is not perfect (real UID instead of effective). I figure this is probably fine and simpler, but maybe it would be worth retrieving euid/egid and comparing with what `stat(2)` said. What do you think?