### PR TITLE
Add option to acquire lock so that only one geoipupdate may run at once

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,9 @@ Unreleased
 
 * `geoipupdate` now checks that the database directory is writable. If it
   is not, it reports the problem and aborts.
+* `geoipupdate` now includes an option, `LockFile`, to specify a file to
+  lock at startup. If set, only one `geoipupdate` instance may run at a
+  time. No `LockFile` is set by default.
 
 2.3.1 (2017-01-05)
 ------------------

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,9 +5,10 @@ Unreleased
 
 * `geoipupdate` now checks that the database directory is writable. If it
   is not, it reports the problem and aborts.
-* `geoipupdate` now includes an option, `LockFile`, to specify a file to
-  lock at startup. If set, only one `geoipupdate` instance may run at a
-  time. No `LockFile` is set by default.
+* `geoipupdate` now acquires a lock when starting up to ensure only one
+  instance may run at a time. A new option, `LockFile`, exists to set the
+  file to use as a lock. By default, `LockFile` is the file
+  `.geoipupdate.lock` in the database directory.
 
 2.3.1 (2017-01-05)
 ------------------

--- a/bin/geoipupdate.h
+++ b/bin/geoipupdate.h
@@ -50,4 +50,7 @@ void *xmalloc(size_t size);
 
 # define NO_USER_ID (-1)
 # define GEOIP_USERAGENT "geoipupdate/" VERSION
+
+#define exit_if(expr, ...) exit_unless(!(expr), ## __VA_ARGS__)
+
 #endif

--- a/bin/geoipupdate.h
+++ b/bin/geoipupdate.h
@@ -29,6 +29,7 @@ typedef struct {
     char * proto;
     char * proxy;               // 1.2.3.4, 1.2.3.4:1234
     char * proxy_user_password; // user:pwd
+    char * lock_file;           // Path to a global runtime lock file.
     int verbose;
     CURL * curl;
 

--- a/bin/geoipupdate_s.c
+++ b/bin/geoipupdate_s.c
@@ -14,6 +14,7 @@ geoipupdate_s *geoipupdate_s_new(void)
     gu->host = strdup("updates.maxmind.com");
     gu->proxy = strdup("");
     gu->proxy_user_password = strdup("");
+    gu->lock_file = strdup("");
     gu->verbose = 0;
     gu->license.user_id = NO_USER_ID;
     gu->license.license_key[12] = 0;
@@ -30,6 +31,7 @@ void geoipupdate_s_delete(geoipupdate_s * gu)
         free(gu->proto);
         free(gu->proxy);
         free(gu->proxy_user_password);
+        free(gu->lock_file);
         free(gu->host);
         if (gu->curl != NULL) {
             curl_easy_cleanup(gu->curl);

--- a/bin/geoipupdate_s.c
+++ b/bin/geoipupdate_s.c
@@ -8,17 +8,43 @@ geoipupdate_s *geoipupdate_s_new(void)
     size_t size = sizeof(geoipupdate_s);
     geoipupdate_s *gu = xmalloc(size);
     memset(gu, 0, size);
+
     gu->license_file = strdup(SYSCONFDIR "/GeoIP.conf");
+    exit_if(NULL == gu->license_file,
+            "Unable to allocate memory for license file path.\n");
+
     gu->database_dir = strdup(DATADIR);
+    exit_if(NULL == gu->database_dir,
+            "Unable to allocate memory for database directory path.\n");
+
     gu->proto = strdup("https");
+    exit_if(NULL == gu->proto,
+            "Unable to allocate memory for request protocol.\n");
+
     gu->host = strdup("updates.maxmind.com");
+    exit_if(NULL == gu->host,
+            "Unable to allocate memory for update host.\n");
+
     gu->proxy = strdup("");
+    exit_if(NULL == gu->proxy,
+            "Unable to allocate memory for proxy host.\n");
+
     gu->proxy_user_password = strdup("");
+    exit_if(NULL == gu->proxy_user_password,
+            "Unable to allocate memory for proxy credentials.\n");
+
     gu->lock_file = strdup("");
+    exit_if(NULL == gu->lock_file,
+            "Unable to allocate memory for lock file path.\n");
+
     gu->verbose = 0;
     gu->license.user_id = NO_USER_ID;
     gu->license.license_key[12] = 0;
+
     gu->curl = curl_easy_init();
+    exit_if(NULL == gu->curl,
+            "Unable to initialize curl.\n");
+
     return gu;
 }
 

--- a/bin/product_s.c
+++ b/bin/product_s.c
@@ -39,6 +39,8 @@ product_s *product_new(const char *product_id)
 {
     product_s *p = xmalloc(sizeof(product_s));
     p->product_id = strdup(product_id);
+    exit_if(NULL == p->product_id,
+            "Unable to allocate memory for product ID.\n");
     p->next = NULL;
     return p;
 }

--- a/conf/GeoIP.conf.default
+++ b/conf/GeoIP.conf.default
@@ -43,7 +43,7 @@ ProductIds GeoLite2-Country GeoLite2-City
 # Defaults to "0".
 # SkipPeerVerification 0
 
-# The lock file to use. If specified, geoipupdate acquires a lock on the file
-# at startup. This ensures only one geoipupdate process can run at a time.
-# Defaults to "" which means no locking.
-# LockFile /var/lock/geoipupdate.lock
+# The lock file to use. This ensures only one geoipupdate process can run at a
+# time.
+# Defaults to ".geoipupdate.lock" under the DatabaseDirectory.
+# LockFile /usr/local/share/GeoIP/.geoipupdate.lock

--- a/conf/GeoIP.conf.default
+++ b/conf/GeoIP.conf.default
@@ -42,3 +42,8 @@ ProductIds GeoLite2-Country GeoLite2-City
 # Whether to skip peer verification on HTTPS connections.
 # Defaults to "0".
 # SkipPeerVerification 0
+
+# The lock file to use. If specified, geoipupdate acquires a lock on the file
+# at startup. This ensures only one geoipupdate process can run at a time.
+# Defaults to "" which means no locking.
+# LockFile /var/lock/geoipupdate.lock


### PR DESCRIPTION
This adds a new option, `LockFile`, which by default is empty. If set, it is a path to a file to open and acquire a lock on. This happens at startup and is to make it so only a single `geoipupdate` can run at once.