### PR TITLE
Replace use of strnlen

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,8 @@
 GeoIP Update Change Log
 =======================
 
+* Replace use of strnlen() due to lack of universal availability. First
+  reported by Bill Cole. GitHub issue #71.
 * Remove unused base64 library. PR by Mikhail Teterin. GitHub PR #68.
 * Add the new configuration option `PreserveFileTimes`. If set,
   the downloaded files will get the same modification times as

--- a/bin/functions.h
+++ b/bin/functions.h
@@ -2,7 +2,9 @@
 #define _GEOIPUPDATE_FUNCTIONS_H
 
 #include <stdbool.h>
+#include <stddef.h>
 
+size_t gu_strnlen(char const * const, size_t const);
 bool is_valid_gzip_file(char const * const);
 char * slurp_file(char const * const);
 

--- a/bin/geoipupdate.c
+++ b/bin/geoipupdate.c
@@ -590,14 +590,13 @@ static void download_to_file(geoipupdate_s * gu, const char *url,
 
     // In this case, the server must have told us the current MD5 hash of the
     // database we asked for.
-    if (strnlen(expected_file_md5, 33) != 32) {
+    if (gu_strnlen(expected_file_md5, 33) != 32) {
         fprintf(stderr,
                 "Did not receive a valid expected database MD5 from server\n");
         unlink(fname);
         exit(1);
     }
 }
-
 
 // Retrieve the server file time for the previous HTTP request.
 static long get_server_time(geoipupdate_s * gu)

--- a/bin/geoipupdate.c
+++ b/bin/geoipupdate.c
@@ -691,7 +691,7 @@ static void md5hex_license_ipaddr(geoipupdate_s * gu, const char *client_ipaddr,
 static int update_database_general(geoipupdate_s * gu, const char *product_id)
 {
     char *url = NULL, *geoip_filename = NULL, *geoip_gz_filename = NULL,
-    *client_ipaddr = NULL;
+         *client_ipaddr = NULL;
     char hex_digest[33] = { 0 }, hex_digest2[33] = { 0 };
 
     // Get the filename.


### PR DESCRIPTION
This implements a version of strnlen internally. strnlen is not part of
C99 and is not available on all systems. This is to fix #71.