### PR TITLE
Document LockFile behavior

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,9 @@
 GeoIP Update Change Log
 =======================
 
+* Document that the `LockFile` is not removed from the filesystem after
+  a successful exit from the program. GitHub issue #79.
+
 2.5.0 (2017-10-30)
 ------------------
 

--- a/conf/GeoIP.conf.default
+++ b/conf/GeoIP.conf.default
@@ -45,5 +45,6 @@ EditionIDs GeoLite2-Country GeoLite2-City
 
 # The lock file to use. This ensures only one geoipupdate process can run at a
 # time.
+# Note: Once created, this lockfile is not removed from the filesystem.
 # Defaults to ".geoipupdate.lock" under the DatabaseDirectory.
 # LockFile /usr/local/share/GeoIP/.geoipupdate.lock

--- a/man/GeoIP.conf.5.in
+++ b/man/GeoIP.conf.5.in
@@ -68,7 +68,9 @@ This option is either
 .B LockFile
 The lock file to use. This ensures only one
 .B geoipupdate
-process can run at a time. The default is
+process can run at a time. 
+Note: Once created, this lockfile is not removed from the filesystem. 
+The default is
 .BR .geoipupdate.lock " under the " DatabaseDirectory .
 .SH FILES
 .PP


### PR DESCRIPTION
As discussed in #79, it wasn't obvious to users that the lockfile remains on the filesystem
even after a successful exit from the program. This commit adds documentation of this behavior
to the config file and the man page.