### PR TITLE
Update GeoIP.conf dynamically so that the paths in it are accurate

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,10 @@
 GeoIP Update Change Log
 =======================
 
+* We now update the default GeoIP.conf during installation so that
+  directory paths match build parameters. Previously this config always
+  said the data directory was under /usr/local/share which was not always
+  accurate.
 * Improve the error checking and display the underlying reason for the
   error when possible. Reported by Jonathan Kosgei. GitHub #82.
 * Document that the `LockFile` is not removed from the filesystem after

--- a/conf/GeoIP.conf.default
+++ b/conf/GeoIP.conf.default
@@ -14,8 +14,8 @@ EditionIDs GeoLite2-Country GeoLite2-City
 
 # The remaining settings are OPTIONAL.
 
-# The directory to store the database files. Defaults to /usr/local/share/GeoIP
-# DatabaseDirectory /usr/local/share/GeoIP
+# The directory to store the database files. Defaults to DATADIR
+# DatabaseDirectory DATADIR
 
 # The server to use. Defaults to "updates.maxmind.com".
 # Host updates.maxmind.com
@@ -47,4 +47,4 @@ EditionIDs GeoLite2-Country GeoLite2-City
 # time.
 # Note: Once created, this lockfile is not removed from the filesystem.
 # Defaults to ".geoipupdate.lock" under the DatabaseDirectory.
-# LockFile /usr/local/share/GeoIP/.geoipupdate.lock
+# LockFile DATADIR/.geoipupdate.lock

--- a/conf/GeoIP.conf.default
+++ b/conf/GeoIP.conf.default
@@ -1,4 +1,4 @@
-# Please see http://dev.maxmind.com/geoip/geoipupdate/ for instructions
+# Please see https://dev.maxmind.com/geoip/geoipupdate/ for instructions
 # on setting up geoipupdate, including information on how to download a
 # pre-filled GeoIP.conf file.
 

--- a/conf/Makefile.am
+++ b/conf/Makefile.am
@@ -8,13 +8,13 @@ install-exec-hook:
 		$(MKDIR_P) "$(DESTDIR)$(sysconfdir)" ; \
 	fi
 	@if [ -f "$(DESTDIR)$(DEFAULT_CONFIG_FILE)" ]; then \
-	        echo "$@ will not overwrite existing $(DESTDIR)$(DEFAULT_CONFIG_FILE)" ; \
+		echo "$@ will not overwrite existing $(DESTDIR)$(DEFAULT_CONFIG_FILE)" ; \
 	else \
-	        echo "$(INSTALL_DATA) GeoIP.conf.default $(DESTDIR)$(DEFAULT_CONFIG_FILE)"; \
-	        $(INSTALL_DATA) "$(srcdir)/GeoIP.conf.default" "$(DESTDIR)$(DEFAULT_CONFIG_FILE)"; \
+		echo "$(INSTALL_DATA) GeoIP.conf.default $(DESTDIR)$(DEFAULT_CONFIG_FILE)"; \
+		$(INSTALL_DATA) "$(srcdir)/GeoIP.conf.default" "$(DESTDIR)$(DEFAULT_CONFIG_FILE)"; \
 	fi
 
 uninstall-hook:
 	@if test -f "$(DESTDIR)$(DEFAULT_CONFIG_FILE)" ; then \
 		rm "$(DESTDIR)$(DEFAULT_CONFIG_FILE)"; \
-fi
+	fi

--- a/conf/Makefile.am
+++ b/conf/Makefile.am
@@ -2,6 +2,8 @@ DEFAULT_CONFIG_FILE = $(sysconfdir)/GeoIP.conf
 
 EXTRA_DIST=GeoIP.conf.default
 
+edit = sed -e 's|DATADIR|$(datadir)/GeoIP|g'
+
 install-exec-hook:
 	@if [ ! -d "$(DESTDIR)$(sysconfdir)" ]; then \
 		echo "$(MKDIR_P) $(DESTDIR)$(sysconfdir)" ; \
@@ -10,8 +12,10 @@ install-exec-hook:
 	@if [ -f "$(DESTDIR)$(DEFAULT_CONFIG_FILE)" ]; then \
 		echo "$@ will not overwrite existing $(DESTDIR)$(DEFAULT_CONFIG_FILE)" ; \
 	else \
-		echo "$(INSTALL_DATA) GeoIP.conf.default $(DESTDIR)$(DEFAULT_CONFIG_FILE)"; \
-		$(INSTALL_DATA) "$(srcdir)/GeoIP.conf.default" "$(DESTDIR)$(DEFAULT_CONFIG_FILE)"; \
+		echo "$(INSTALL_DATA) GeoIP.conf $(DESTDIR)$(DEFAULT_CONFIG_FILE)"; \
+		$(edit) "$(srcdir)/GeoIP.conf.default" > "$(srcdir)/GeoIP.conf"; \
+		$(INSTALL_DATA) "$(srcdir)/GeoIP.conf" "$(DESTDIR)$(DEFAULT_CONFIG_FILE)"; \
+		rm "$(srcdir)/GeoIP.conf"; \
 	fi
 
 uninstall-hook:

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -2,7 +2,6 @@ man_MANS = geoipupdate.1 GeoIP.conf.5
 
 EXTRA_DIST = geoipupdate.1.in GeoIP.conf.5.in
 
-
 edit = sed \
 	-e 's|DATADIR|$(datadir)/GeoIP|g' \
 	-e 's|CONF_DIR|$(sysconfdir)|g'
@@ -22,12 +21,3 @@ geoipupdate.1: Makefile
 geoipupdate.1: geoipupdate.1.in
 
 CLEANFILES = geoipupdate.1 GeoIP.conf.5
-
-UPDATE_MAN1 = $(mandir)/man1/geoipupdate.1
-
-UPDATE_MAN5 = $(mandir)/man5/GeoIP.conf.5
-
-install-data-hook:
-	cat geoipupdate.1 | sed s,DATADIR,$(pkgdatadir), | sed s,CONF_DIR,$(sysconfdir), > $(DESTDIR)$(UPDATE_MAN1)
-	cat GeoIP.conf.5 | sed s,DATADIR,$(pkgdatadir), | sed s,CONF_DIR,$(sysconfdir), > $(DESTDIR)$(UPDATE_MAN5)
-


### PR DESCRIPTION
The paths were previously hardcoded. Given they can change depending on how you build geoipupdate, we should update them during build/install.