### PR TITLE
Add a Dockerfile to support building docker containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+# create container stage to build out package
+FROM alpine:3.6
+
+# copy the source code into the container
+COPY ./ /tmp/geoipupdate/
+# run all of our commands inside the project source code
+WORKDIR /tmp/geoipupdate
+# install the development dependencies needed to compile the project
+RUN apk add --update \
+        autoconf \
+        automake \
+        libtool \
+        alpine-sdk \
+        zlib-dev \
+        curl-dev
+
+# build the project
+RUN ./bootstrap
+RUN ./configure
+RUN make
+RUN make install
+
+# create a new image that contains only the binary
+FROM alpine:3.6
+# install the libraries needed to run the project
+RUN apk add --update libcurl zlib
+# copy over the compiled project files from the build step
+COPY --from=0 /usr/local/bin/geoipupdate /usr/local/bin/geoipupdate
+COPY --from=0 /usr/local/etc/GeoIP.conf /usr/local/etc/GeoIP.conf
+COPY --from=0 /usr/local/share/doc/geoipupdate /usr/local/share/doc/geoipupdate
+COPY --from=0 /usr/local/share/GeoIP /usr/local/share/GeoIP
+# use the binary as the entrypoint for the image
+ENTRYPOINT ["/usr/local/bin/geoipupdate"]


### PR DESCRIPTION
This PR adds a Dockerfile to help with generating Docker images for the project. This can be helpful when running containerized production environments in Docker swarm or Kubernetes. The resulting Docker image will use the geoipupdate binary as it's entrypoint. To use the container, you must mount the `GeoIP.conf` configuration file into the correct location within the container (`/usr/local/etc/GeoIP.conf`). 

_Note: Since this is using the multi-stage build, this will only support **Docker 17.05+**_

Docs: https://docs.docker.com/develop/develop-images/multistage-build/
